### PR TITLE
Feature/custom actions icon

### DIFF
--- a/module/conversation/ConversationItem.tsx
+++ b/module/conversation/ConversationItem.tsx
@@ -42,6 +42,7 @@ export interface ConversationItemProps {
     visible?: boolean;
     icon?: ReactNode;
     actions: Array<{
+      icon?: ReactNode;
       content: ReactNode;
       onClick?: (cvs: ConversationData[0]) => void | Promise<boolean>;
     }>;
@@ -266,6 +267,7 @@ let ConversationItem: FC<ConversationItemProps> = props => {
                 item.onClick?.(data);
               }}
             >
+              {item.icon || null}
               {item.content}
             </li>
           );

--- a/module/messageInput/MessageInput.stories.tsx
+++ b/module/messageInput/MessageInput.stories.tsx
@@ -3,6 +3,7 @@ import { StoryFn, Meta } from '@storybook/react';
 
 import MessageInput from './index';
 import Provider from '../store/Provider';
+import Icon from '../../component/icon';
 
 // 添加中文和英文的描述
 const lang = import.meta.env.VITE_CUSTOM_VAR as 'en' | 'zh';
@@ -144,7 +145,7 @@ export default {
       control: 'object',
       description: description[lang].customActions,
       table: {
-        type: { summary: 'Action[]' },
+        type: { summary: 'CustomAction[]' },
         defaultValue: {
           summary:
             '[{ content: "FILE" }, { content: "IMAGE" }, { content: "VIDEO" }, { content: "CARD" }]',
@@ -206,4 +207,36 @@ export const Dark = {
 
 export const Square = {
   render: SquareTemplate,
+};
+
+// 自定义图标示例
+const CustomIconTemplate: StoryFn<typeof MessageInput> = args => (
+  <Provider initConfig={{ appKey: 'z#b' }}>
+    <MessageInput
+      {...args}
+      conversation={{ chatType: 'singleChat', conversationId: 'zd2' }}
+      customActions={[
+        {
+          content: '收藏',
+          icon: <Icon type="STAR" />,
+          onClick: () => console.log('收藏'),
+        },
+        {
+          content: '大图标',
+          icon: <Icon type="STAR" />,
+          iconSize: 24,
+          onClick: () => console.log('大图标'),
+        },
+        {
+          content: '默认尺寸',
+          // 不传icon，使用默认 PLUS_CIRCLE 图标
+          onClick: () => console.log('默认'),
+        },
+      ]}
+    />
+  </Provider>
+);
+
+export const CustomIcon = {
+  render: CustomIconTemplate,
 };

--- a/module/messageInput/moreAction/MoreAction.tsx
+++ b/module/messageInput/moreAction/MoreAction.tsx
@@ -1,4 +1,12 @@
-import React, { useState, ReactNode, useRef, useContext } from 'react';
+import React, {
+  useState,
+  ReactNode,
+  useRef,
+  useContext,
+  ReactElement,
+  cloneElement,
+  isValidElement,
+} from 'react';
 import classNames from 'classnames';
 import './style/style.scss';
 import { ConfigContext } from '../../../component/config/index';
@@ -22,6 +30,7 @@ export interface MoreActionProps {
     content: string;
     onClick?: () => void;
     icon?: ReactNode;
+    iconSize?: number; // 图标尺寸，默认 18
   }>;
   conversation?: CurrentConversation;
   isChatThread?: boolean;
@@ -199,6 +208,16 @@ let MoreAction = (props: MoreActionProps) => {
             </li>
           );
         }
+        // 渲染自定义图标，支持 iconSize
+        const renderCustomIcon = (icon: ReactNode, iconSize: number = 18) => {
+          if (!isValidElement(icon)) return icon;
+          // 尝试注入 width 和 height 属性
+          return cloneElement(icon as ReactElement<any>, {
+            width: iconSize,
+            height: iconSize,
+          });
+        };
+
         return (
           <li
             className={themeMode == 'dark' ? 'cui-li-dark' : ''}
@@ -208,7 +227,15 @@ let MoreAction = (props: MoreActionProps) => {
             }}
             key={item.content || index}
           >
-            {item.icon || <Icon type="PLUS_CIRCLE" width={18} height={18}></Icon>}
+            {item.icon ? (
+              <span className={`${prefixCls}-custom-icon`}>
+                {renderCustomIcon(item.icon, item.iconSize)}
+              </span>
+            ) : (
+              <span className={`${prefixCls}-default-icon`}>
+                <Icon type="PLUS_CIRCLE" width={18} height={18}></Icon>
+              </span>
+            )}
             {item.content}
           </li>
         );

--- a/module/messageInput/moreAction/MoreAction.tsx
+++ b/module/messageInput/moreAction/MoreAction.tsx
@@ -208,6 +208,7 @@ let MoreAction = (props: MoreActionProps) => {
             }}
             key={item.content || index}
           >
+            {item.icon || <Icon type="PLUS_CIRCLE" width={18} height={18}></Icon>}
             {item.content}
           </li>
         );

--- a/module/messageInput/moreAction/style/style.scss
+++ b/module/messageInput/moreAction/style/style.scss
@@ -41,4 +41,27 @@ $moreAction-prefix-cls: #{$cui-prefix}-moreAction;
         justify-content: center;
         align-items: center;
     }
+
+    // 自定义图标容器样式（自适应图标尺寸）
+    &-custom-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        margin-right: 8px;
+        flex-shrink: 0;
+        // 最小尺寸保持与默认一致
+        min-width: 18px;
+        min-height: 18px;
+    }
+
+    // 默认图标样式（未传入自定义 icon 时）
+    &-default-icon {
+        width: 18px;
+        height: 18px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        margin-right: 8px;
+        flex-shrink: 0;
+    }
 }


### PR DESCRIPTION

- Add iconSize property to customActions type definition
- Auto-inject width/height to custom icon via cloneElement
- Default iconSize to 18px to match built-in action icons
- Add custom-icon and default-icon style containers